### PR TITLE
Enhancements to functionality

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,6 +4,8 @@ http://www.ajlopez.com
 http://ajlopez.wordpress.com
 http://twitter.com/ajlopez
 
+Copyright (c) 2016, Sergei Winitzki
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ npm test
 
 - 0.0.1: Published
 
+- 0.0.2: Variables can be named by pattern [a-z][0-9]*. Parsing refactored. Alpha-conversion works correctly now.
+
+- 0.0.3: Support HTML output. Syntax can accept \x->y as well as Unicode symbols (Î»xâ†’y).
+
+- 0.0.4: Option to keep bodies of lambda functions from reduction. More conservative (thus less confusing) alpha-conversions.
+
 ## License
 
 MIT
@@ -61,13 +67,13 @@ MIT
 ## References
 
 - [Lecture Notes on the Lambda Calculus](http://www.mscs.dal.ca/~selinger/papers/lambdanotes.pdf).
-- [Notas sobre el Cálculo Lambda](http://ajlopez.zoomblog.com/archivo/2009/04/14/notas-sobre-el-Calculo-Lambda.html)
+- [Notas sobre el CÃ¡lculo Lambda](http://ajlopez.zoomblog.com/archivo/2009/04/14/notas-sobre-el-Calculo-Lambda.html)
 
 ## Contribution
 
 Feel free to [file issues](https://github.com/ajlopez/SimpleLambda) and submit
-[pull requests](https://github.com/ajlopez/SimpleLambda/pulls) — contributions are
-welcome<
+[pull requests](https://github.com/ajlopez/SimpleLambda/pulls) - contributions are
+welcome.
 
 If you submit a pull request, please be sure to add or update corresponding
 test cases, and ensure that `npm test` continues to pass.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ npm test
 
 - 0.0.4: Option to keep bodies of lambda functions from reduction. More conservative (thus less confusing) alpha-conversions.
 
+- 0.0.5: Support capitalized multi-letter variables (e.g. Case ) with obligatory separator
+
+- 0.0.6: Support empty separator for lambdas (\x y or \x \y z).
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ while (term) {
 ## Development
 
 ```
-git clone git://github.com/ajlopez/SimpleLambda.git
+git clone git://github.com/winitzki/SimpleLambda.git
 cd SimpleLambda
 npm install
 npm test
@@ -48,7 +48,7 @@ npm test
 
 ## Samples
 
-- [Simple Reduces](https://github.com/ajlopez/SimpleLambda/tree/master/samples/simple) Simple reduce examples.
+- [Simple Reduces](https://github.com/winitzki/SimpleLambda/tree/master/samples/simple) Simple reduce examples.
 
 ## Versions
 

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -88,7 +88,7 @@ function Variable(name) {
 }
 
 function isIdentifier(text) {
-  return (text && typeof(text) == typeof("") && text.length > 0 && text.match(/^[a-z][0-9]*$/) );
+  return (text && typeof(text) == typeof("") && text.length > 0 && text.match(/^([a-z][0-9]*|[A-Z][a-z0-9]*)$/) );
 }
 
 function makeFreshName(boundVars) {
@@ -329,7 +329,7 @@ function parse(text) {
     return term;
   }
 
-  function parseVarName() { // [a-z][0-9]*
+  function parseVarName() { // [a-z][0-9]* | [A-Z][a-z0-9]*
 
     var name = text[p];
     if (name >= 'a' && name <= 'z') {
@@ -339,7 +339,13 @@ function parse(text) {
         p++;
       }
       return name;
-
+    } else if (name >= 'A' && name <= 'Z') {
+      p++;
+      while (p < l && (text[p] <= '9' && text[p] >= '0' || text[p] <= 'z' && text[p] >= 'a')) {
+        name += text[p];
+        p++;
+      }
+      return name;
     } else {
       return null;
     }

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -5,6 +5,38 @@ var freshCounter = 0;
 * Variables must be lowercase.
 * */
 
+function isEqual(term1, term2) {
+  if (isVariable(term1) && isVariable(term2) && term1.getName() == term2.getName()) {
+    return true;
+  }
+  if (isApply(term1) && isApply(term2) && isEqual(term1.getLeft(), term2.getLeft()) && isEqual(term1.getRight(), term2.getRight())) {
+    return true;
+  }
+  if (isLambda(term1) && isLambda(term2)) {
+    if (term1.getBoundName() == term2.getBoundName() && isEqual(term1.getBody(), term2.getBody())) {
+      return true;
+    }
+    else {
+      var term2AlphaConverted = term2.substitute(term2.getBoundName(), new Variable(term1.getBoundName()));
+
+      if (isEqual(term1.getBody(), term2AlphaConverted.getBody())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function isVariable(term) {
+  return Variable.prototype.isPrototypeOf(term);
+}
+function isLambda(term) {
+  return Lambda.prototype.isPrototypeOf(term);
+}
+function isApply(term) {
+  return Apply.prototype.isPrototypeOf(term);
+}
+
 function Variable(name) {
   if (!isIdentifier(name))
     throw "invalid variable name";
@@ -52,7 +84,7 @@ function isIdentifier(text) {
 
 function makeFreshName(boundVars) {
   var minIndex = 0;
-  var shortVars = "xyzwvutsrabcdefghijklmnopq";
+  var shortVars = "xyzwvutsrabcdefghijklmnpq";
 
   if (boundVars) {
     boundVars.forEach(function(bVar){
@@ -74,6 +106,14 @@ function makeFreshName(boundVars) {
 
 function Lambda(name, term) {
 
+  this.getBoundName = function() {
+    return name;
+  };
+
+  this.getBody = function() {
+    return term;
+  };
+
   var boundVar = new Variable(name);
 
   this.toString = function () {
@@ -87,7 +127,7 @@ function Lambda(name, term) {
 
   // note: we have two different substitutions, one for the bound variable - and it can only be substituted by another variable, which is alpha-conversion - and another when we substitute a free variable by a new term, which is beta-conversion
   this.substitute = function (varname, newterm) {
-    if (name === varname && !Variable.prototype.isPrototypeOf(newterm)) {
+    if (name === varname && !isVariable(newterm)) {
       console.log('invalid usage: cannot substitute x by a non-variable in \\x->...; ignored.');
       return this;
     }
@@ -130,28 +170,37 @@ function Lambda(name, term) {
 }
 
 function Apply(left, right) {
+
+  this.getLeft = function() {
+    return left;
+  };
+
+  this.getRight = function() {
+    return right;
+  };
+
   this.toHTML = function (boundVars) {
     if (typeof(boundVars)!=typeof([])) boundVars = [];
     var leftstr = left.toHTML(boundVars);
     var rightstr = right.toHTML(boundVars);
 
-    if (Apply.prototype.isPrototypeOf(right) || Lambda.prototype.isPrototypeOf(right))
+    if (isApply(right) || isLambda(right))
       rightstr = "(" + rightstr + ")";
 
-    if (Lambda.prototype.isPrototypeOf(left))
-      leftstr = "&nbsp;(" + leftstr + ")&nbsp;";
+    if (isLambda(left))
+      leftstr = "(" + leftstr + ")";
 
-    return leftstr + rightstr;
+    return leftstr + "&nbsp;" + rightstr;
   };
 
   this.toString = function () {
     var leftstr = left.toString();
     var rightstr = right.toString();
 
-    if (Apply.prototype.isPrototypeOf(right) || Lambda.prototype.isPrototypeOf(right))
+    if (isApply(right) || isLambda(right))
       rightstr = "(" + rightstr + ")";
 
-    if (Lambda.prototype.isPrototypeOf(left))
+    if (isLambda(left))
       leftstr = "(" + leftstr + ")";
 
     return leftstr + rightstr;
@@ -178,7 +227,7 @@ function Apply(left, right) {
     if (rreduce)
       return new Apply(left, rreduce);
 
-    if (!Lambda.prototype.isPrototypeOf(left))
+    if (!isLambda(left))
       return null;
 
     return left.apply(right);
@@ -321,6 +370,10 @@ module.exports = {
   createVariable: createVariable,
   createLambda: createLambda,
   createApply: createApply,
+  isLambda: isLambda,
+  isApply: isApply,
+  isVariable: isVariable,
+  isEqual: isEqual,
   reduce: reduce,
   parse: parse
 };

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -59,6 +59,10 @@ function Variable(name) {
     return name;
   };
 
+  this.alphaConvert = function(varName, newName) {
+      return this;
+  };
+
   this.substitute = function (varname, newterm) {
     if (name === varname)
       return newterm;
@@ -99,7 +103,6 @@ function makeFreshName(boundVars) {
       }
     });
     var newName = (shortVars.length > 0) ? shortVars.charAt(0) : "v" + minIndex;
-//    console.log('makeFreshName', boundVars, 'returns', newName);
     return newName;
   }
 
@@ -127,24 +130,33 @@ function Lambda(name, term) {
     return "λ" + boundVar.toHTML([name]) + "→" + term.toHTML([name].concat(boundVars));
   };
 
-  // note: we have two different substitutions, one for the bound variable - and it can only
+  // note: in the old code, we have two different substitutions, one for the bound variable - and it can only
   // be substituted by another variable, which is alpha-conversion - and another when we
   // substitute a free variable by a new term, which is beta-conversion
-  this.substitute = function (varname, newterm) {
-    if (name === varname && !isVariable(newterm)) {
-      console.log('invalid usage: cannot substitute x by a non-variable in \\x->...; ignored.');
+  // So actually we have to separate them! Otherwise we get a confusing (even though correct) alpha-conversion such as in
+  // (\x.(\x.x)) p  yielding \p.p instead of \x.x
+
+  // after alpha conversion, term should not have varname as a free variable
+  this.alphaConvert = function(varName, newname) {
+    if (name == varName && term.hasFree(newname)) {
+      return new Lambda(newname, term.alphaConvert(varName, newname));
+    } else {
       return this;
     }
+  };
 
-    if (name !== varname && newterm.hasFree(name)) { // need alpha-conversion
-      var newname = makeFreshName(term.getFreeVars().concat(newterm.getFreeVars())); // guarantee that newname is not free in our term and in newterm
-      var term2 = term.substitute(name, new Variable(newname)).substitute(varname, newterm);
+  this.substitute = function (varName, newTerm) {
+
+    if (name !== varName && newTerm.hasFree(name)) { // need alpha-conversion
+      var newname = makeFreshName(term.getFreeVars().concat(newTerm.getFreeVars())); // guarantee that newname is not free in our term or in newterm
+      var term2 = term.alphaConvert(name, newname).substitute(varName, newTerm);
+      //console.log('substitute at term', this.toString(), 'has newname', newname, 'term.ac(', name, ',', newname, ')=', term.alphaConvert(name, newname).toString(), 'term2=', term2.toString());
       return new Lambda(newname, term2);
     }
 
-    var body = term.substitute(varname, newterm);
+    var body = term.substitute(varName, newTerm);
 
-    if (name !== varname)
+    if (name !== varName)
       if (body === term)
         return this;
       else
@@ -152,12 +164,18 @@ function Lambda(name, term) {
 
     else {
       // if we are here, newterm is a variable, and we are simply alpha-renaming ourselves
-      return new Lambda(newterm.getName(), body);
+      return new Lambda(newTerm.getName(), body);
     }
   };
 
   this.apply = function (newterm) {
-    return term.substitute(name, newterm);
+    // the variable 'name' may be either missing or present and free in 'newterm'.
+    if (newterm.hasFree(name)) {
+      // any bound instances of 'name' in 'newterm' are ignored by the substitution.
+      return term.substitute(name, newterm);
+    } else {
+      return term;
+    }
   };
 
   this.reduce = function(options) {
@@ -220,14 +238,18 @@ function Apply(left, right) {
     return leftstr + rightstr;
   };
 
+  this.alphaConvert = function(varName, newName) {
+    return new Apply(left.alphaConvert(varName, newName), right.alphaConvert(varName, newName));
+  };
+
   this.substitute = function (varname, newterm) {
     var newleft = left.substitute(varname, newterm);
     var newright = right.substitute(varname, newterm);
 
     if (newleft === left && newright === right)
       return this;
-
-    return new Apply(newleft, newright);
+    else
+      return new Apply(newleft, newright);
   };
 
   this.reduce = function () {

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -1,7 +1,7 @@
 var freshCounter = 0;
 
-var lambdaSeparator = '.'; // →
-var lambdaHead = 'λ';
+var lambdaSeparatorForHtml = '.'; // →
+var lambdaHeadForHtml = 'λ';
 
 /* Each term has methods toString, toHTML, substitute, hasFree, and getFreeVars.
 * Only Apply and Lambda have the method 'reduce'. Only 'Lambda' has the method 'apply'.
@@ -130,7 +130,7 @@ function Lambda(boundName, lambdaBody) {
 
   this.toHTML = function(boundVars) {
     if (typeof(boundVars)!=typeof([])) boundVars = [];
-    return lambdaHead + boundVar.toHTML([boundName]) + lambdaSeparator + lambdaBody.toHTML([boundName].concat(boundVars));
+    return lambdaHeadForHtml + boundVar.toHTML([boundName]) + lambdaSeparatorForHtml + lambdaBody.toHTML([boundName].concat(boundVars));
   };
 
   // note: in the old code, we have two different substitutions, one for the bound variable - and it can only
@@ -383,18 +383,18 @@ function parse(text) {
     var varName = parseVarName();
     if (varName) return new Variable(varName);
 
-    if (parseCharRange("\\λ" || parseFixedString(lambdaHead))) {
+    if (parseCharRange("\\λ" || parseFixedString(lambdaHeadForHtml))) {
       var name = parseVarName();
 
       if (!name)
         throw "Invalid argument name";
 
-      if (parseCharRange(".→") || parseFixedString('->') || parseFixedString(lambdaSeparator)) {
-        var body = parseTerms();
-        return new Lambda(name, body);
-      } else {
-        throw "Expected a lambda separator";
-      }
+      // allow empty lambda separator, as well as a given set of separators
+      if (parseCharRange(".→") || parseFixedString('->') || parseFixedString(lambdaSeparatorForHtml)) {}
+
+      var body = parseTerms();
+      return new Lambda(name, body);
+
     }
 
     if (parseCharRange("(")) {
@@ -421,7 +421,7 @@ module.exports = {
   isEqual: isEqual,
   reduce: reduce,
   parse: parse,
-  setLambdaHead: function(lh){lambdaHead = lh;},
-  setLambdaSeparator:  function(lh){lambdaSeparator = lh;}
+  setLambdaHead: function(lh){lambdaHeadForHtml = lh;},
+  setLambdaSeparator:  function(lh){lambdaSeparatorForHtml = lh;}
 };
 

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -1,5 +1,8 @@
 var freshCounter = 0;
 
+var lambdaSeparator = '.'; // →
+var lambdaHead = 'λ';
+
 /* Each term has methods toString, toHTML, substitute, hasFree, and getFreeVars.
 * Only Apply and Lambda have the method 'reduce'. Only 'Lambda' has the method 'apply'.
 * Variables must be lowercase.
@@ -19,8 +22,7 @@ function isEqual(term1, term2) {
       return true;
     }
     else {
-      var term2AlphaConverted = term2.substitute(term2.getBoundName(), new Variable(term1.getBoundName()));
-
+      var term2AlphaConverted = term2.alphaConvert(term2.getBoundName(), term1.getBoundName());
       if (isEqual(term1.getBody(), term2AlphaConverted.getBody())) {
         return true;
       }
@@ -59,9 +61,10 @@ function Variable(name) {
     return name;
   };
 
-  this.alphaConvert = function(varName, newName) {
-      return this;
-  };
+  // alpha conversion is the same as substitution for variables
+  //this.alphaConvert = function(varName, newName) {
+  //    return (varName == name) ? new Variable(newName) : this;
+  //};
 
   this.substitute = function (varname, newterm) {
     if (name === varname)
@@ -78,9 +81,9 @@ function Variable(name) {
     return [name];
   };
 
-  this.getName = function() {
+  this.getName = function () {
     return name;
-  }
+  };
 
 }
 
@@ -109,25 +112,25 @@ function makeFreshName(boundVars) {
   return shortVars.charAt(0);
 }
 
-function Lambda(name, term) {
+function Lambda(boundName, lambdaBody) {
 
   this.getBoundName = function() {
-    return name;
+    return boundName;
   };
 
   this.getBody = function() {
-    return term;
+    return lambdaBody;
   };
 
-  var boundVar = new Variable(name);
+  var boundVar = new Variable(boundName);
 
   this.toString = function () {
-    return "\\" + boundVar.toString() + "." + term.toString();
+    return "\\" + boundVar.toString() + "." + lambdaBody.toString();
   };
 
   this.toHTML = function(boundVars) {
     if (typeof(boundVars)!=typeof([])) boundVars = [];
-    return "λ" + boundVar.toHTML([name]) + "→" + term.toHTML([name].concat(boundVars));
+    return lambdaHead + boundVar.toHTML([boundName]) + lambdaSeparator + lambdaBody.toHTML([boundName].concat(boundVars));
   };
 
   // note: in the old code, we have two different substitutions, one for the bound variable - and it can only
@@ -136,66 +139,62 @@ function Lambda(name, term) {
   // So actually we have to separate them! Otherwise we get a confusing (even though correct) alpha-conversion such as in
   // (\x.(\x.x)) p  yielding \p.p instead of \x.x
 
-  // after alpha conversion, term should not have varname as a free variable
-  this.alphaConvert = function(varName, newname) {
-    if (name == varName && term.hasFree(newname)) {
-      return new Lambda(newname, term.alphaConvert(varName, newname));
+  // after alpha conversion, term should not have varname as a free variable. For example, convert (\x.xy) (x, z) will yield (\z.zy)
+  this.alphaConvert = function(varName, newName) {
+    if (boundName == varName && lambdaBody.hasFree(varName)) {
+      var newBody = lambdaBody.substitute(varName, new Variable(newName));
+      return new Lambda(newName, newBody);
     } else {
       return this;
     }
   };
 
   this.substitute = function (varName, newTerm) {
-
-    if (name !== varName && newTerm.hasFree(name)) { // need alpha-conversion
-      var newname = makeFreshName(term.getFreeVars().concat(newTerm.getFreeVars())); // guarantee that newname is not free in our term or in newterm
-      var term2 = term.alphaConvert(name, newname).substitute(varName, newTerm);
-      //console.log('substitute at term', this.toString(), 'has newname', newname, 'term.ac(', name, ',', newname, ')=', term.alphaConvert(name, newname).toString(), 'term2=', term2.toString());
-      return new Lambda(newname, term2);
+    // if we are substituting varName for newTerm but our own bound variable is the same as varName, we do not need to substitute anything.
+    // if newTerm has the same free variable as our own bound name, we have a conflict. We need to alpha-convert ourselves to a new bound name.
+    // otherwise, we can simply substitute the new term into our own body.
+    if (boundName == varName) {
+      return this;
     }
 
-    var body = term.substitute(varName, newTerm);
-
-    if (name !== varName)
-      if (body === term)
-        return this;
-      else
-        return new Lambda(name, body);
-
-    else {
-      // if we are here, newterm is a variable, and we are simply alpha-renaming ourselves
-      return new Lambda(newTerm.getName(), body);
+    if (newTerm.hasFree(boundName)) { // need alpha-conversion
+      var newName = makeFreshName(lambdaBody.getFreeVars().concat(newTerm.getFreeVars())); // guarantee that newname is not free in our term or in newterm
+      var term2 = lambdaBody.substitute(boundName, new Variable(newName)).substitute(varName, newTerm);
+      return new Lambda(newName, term2);
     }
+
+    return new Lambda(boundName, lambdaBody.substitute(varName, newTerm));
+
   };
 
-  this.apply = function (newterm) {
+  this.apply = function (newTerm) {
     // the variable 'name' may be either missing or present and free in 'newterm'.
-    if (newterm.hasFree(name)) {
+    if (lambdaBody.hasFree(boundName)) {
       // any bound instances of 'name' in 'newterm' are ignored by the substitution.
-      return term.substitute(name, newterm);
+      return lambdaBody.substitute(boundName, newTerm);
     } else {
-      return term;
+      return lambdaBody;
     }
   };
 
   this.reduce = function(options) {
-    if ( (options && options.keepLambdaBody) || !term.reduce)
+    if ( (options && options.keepLambdaBody) || !lambdaBody.reduce)
       return null;
     else {
-      var newTerm = term.reduce();
-      if (newTerm) return new Lambda(name, newTerm);
+      var newTerm = lambdaBody.reduce();
+      if (newTerm) return new Lambda(boundName, newTerm);
       else
         return null;
     }
   };
 
   this.hasFree = function (varname) {
-    return name !== varname && term.hasFree(varname);
+    return boundName !== varname && lambdaBody.hasFree(varname);
   };
 
   this.getFreeVars = function () {
-    var termFreeVars = term.getFreeVars();
-    var index = termFreeVars.indexOf(name); // our variable is not free in the term if it occurs there
+    var termFreeVars = lambdaBody.getFreeVars();
+    var index = termFreeVars.indexOf(boundName); // our variable is not free in the term if it occurs there
     if (index != -1) termFreeVars.splice(index, 1);
     return termFreeVars;
   };
@@ -238,14 +237,13 @@ function Apply(left, right) {
     return leftstr + rightstr;
   };
 
-  this.alphaConvert = function(varName, newName) {
-    return new Apply(left.alphaConvert(varName, newName), right.alphaConvert(varName, newName));
-  };
+// for Apply objects, alpha conversion is the same as substitution
 
   this.substitute = function (varname, newterm) {
     var newleft = left.substitute(varname, newterm);
     var newright = right.substitute(varname, newterm);
 
+    //console.log('apply substitute', varname, newterm.toString(), left.toString(), right.toString(), newleft.toString(), newright.toString());
     if (newleft === left && newright === right)
       return this;
     else
@@ -369,19 +367,18 @@ function parse(text) {
     var varName = parseVarName();
     if (varName) return new Variable(varName);
 
-    if (parseCharRange("\\λ")) {
+    if (parseCharRange("\\λ" || parseFixedString(lambdaHead))) {
       var name = parseVarName();
 
       if (!name)
         throw "Invalid argument name";
 
-      if (parseCharRange(".→") || parseFixedString('->')) {
+      if (parseCharRange(".→") || parseFixedString('->') || parseFixedString(lambdaSeparator)) {
         var body = parseTerms();
         return new Lambda(name, body);
       } else {
         throw "Expected a lambda separator";
       }
-
     }
 
     if (parseCharRange("(")) {
@@ -407,6 +404,8 @@ module.exports = {
   isVariable: isVariable,
   isEqual: isEqual,
   reduce: reduce,
-  parse: parse
+  parse: parse,
+  setLambdaHead: function(lh){lambdaHead = lh;},
+  setLambdaSeparator:  function(lh){lambdaSeparator = lh;}
 };
 

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -243,28 +243,38 @@ function Apply(left, right) {
     var newleft = left.substitute(varname, newterm);
     var newright = right.substitute(varname, newterm);
 
-    //console.log('apply substitute', varname, newterm.toString(), left.toString(), right.toString(), newleft.toString(), newright.toString());
     if (newleft === left && newright === right)
       return this;
     else
       return new Apply(newleft, newright);
   };
 
-  this.reduce = function () {
-    var lreduce = reduce(left);
+  this.reduce = function (options) {
+    var lazyEval = options && options.lazyEvaluation;
+    if (isLambda(left)) {
+      if (lazyEval)
+        return left.apply(right);
+      else {
+        var rreduce = reduce(right);
 
-    if (lreduce)
-      return new Apply(lreduce, right);
+        if (rreduce)
+          return new Apply(left, rreduce);
 
-    var rreduce = reduce(right);
+        return left.apply(right);
+      }
+    } else {
+      var lreduce = reduce(left);
 
-    if (rreduce)
-      return new Apply(left, rreduce);
+      if (lreduce)
+        return new Apply(lreduce, right);
 
-    if (!isLambda(left))
+      var rreduce = reduce(right);
+
+      if (rreduce)
+        return new Apply(left, rreduce);
+
       return null;
-
-    return left.apply(right);
+    }
   };
 
   this.hasFree = function (varname) {

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -1,8 +1,10 @@
 var freshCounter = 0;
 
 /* Each term has methods toString, toHTML, substitute, hasFree, and getFreeVars.
-* Only Apply has the method 'reduce'.
+* Only Apply and Lambda have the method 'reduce'. Only 'Lambda' has the method 'apply'.
 * Variables must be lowercase.
+* The global 'reduce' method now has an option, keepLambdaBody = true, which is false by default.
+* If this option is set to true, the lambda function body will never be reduced until application.
 * */
 
 function isEqual(term1, term2) {
@@ -125,7 +127,9 @@ function Lambda(name, term) {
     return "λ" + boundVar.toHTML([name]) + "→" + term.toHTML([name].concat(boundVars));
   };
 
-  // note: we have two different substitutions, one for the bound variable - and it can only be substituted by another variable, which is alpha-conversion - and another when we substitute a free variable by a new term, which is beta-conversion
+  // note: we have two different substitutions, one for the bound variable - and it can only
+  // be substituted by another variable, which is alpha-conversion - and another when we
+  // substitute a free variable by a new term, which is beta-conversion
   this.substitute = function (varname, newterm) {
     if (name === varname && !isVariable(newterm)) {
       console.log('invalid usage: cannot substitute x by a non-variable in \\x->...; ignored.');
@@ -156,6 +160,17 @@ function Lambda(name, term) {
     return term.substitute(name, newterm);
   };
 
+  this.reduce = function(options) {
+    if ( (options && options.keepLambdaBody) || !term.reduce)
+      return null;
+    else {
+      var newTerm = term.reduce();
+      if (newTerm) return new Lambda(name, newTerm);
+      else
+        return null;
+    }
+  };
+
   this.hasFree = function (varname) {
     return name !== varname && term.hasFree(varname);
   };
@@ -164,7 +179,6 @@ function Lambda(name, term) {
     var termFreeVars = term.getFreeVars();
     var index = termFreeVars.indexOf(name); // our variable is not free in the term if it occurs there
     if (index != -1) termFreeVars.splice(index, 1);
-//    console.log('termFreeVars', termFreeVars, 'index', index, 'splicing', termFreeVars.splice(index, 1));
     return termFreeVars;
   };
 }
@@ -254,9 +268,9 @@ function createLambda(name, term) {
   return new Lambda(name, term);
 }
 
-function reduce(term) {
+function reduce(term, options) {
   if (term.reduce)
-    return term.reduce();
+    return term.reduce(options);
 
   return null;
 }
@@ -286,7 +300,6 @@ function parse(text) {
   }
 
   function parseVarName() { // [a-z][0-9]*
-//    console.log('parseVarName at', p, 'input string:', text);
 
     var name = text[p];
     if (name >= 'a' && name <= 'z') {
@@ -295,7 +308,6 @@ function parse(text) {
         name += text[p];
         p++;
       }
-//      console.log('returns', name);
       return name;
 
     } else {
@@ -319,7 +331,6 @@ function parse(text) {
   }
 
   function parseCharRange(range) {
-//    console.log('parseCharRange at', p, 'input string:', text);
 
     if (p < l && range.indexOf(text[p]) != -1) {
       p++;
@@ -331,7 +342,6 @@ function parse(text) {
 
   // a term is an identifier or a lambda or ( term )
   function parseTerm() {
-//    console.log('parseTerm at', p, 'input string:', text);
     if (skipWhitespaceAndCheckEnd()) return null;
 
     var varName = parseVarName();
@@ -343,17 +353,17 @@ function parse(text) {
       if (!name)
         throw "Invalid argument name";
 
-      if (!parseCharRange(".→") && !parseFixedString('->'))
+      if (parseCharRange(".→") || parseFixedString('->')) {
+        var body = parseTerms();
+        return new Lambda(name, body);
+      } else {
         throw "Expected a lambda separator";
+      }
 
-      var body = parseTerms();
-
-      return new Lambda(name, body);
     }
 
     if (parseCharRange("(")) {
       var term = parseTerms(); // true
-//      console.log('parsing', text, 'position', p, 'term', term.toString());
 
       if (parseCharRange(")")) {
         return term;

--- a/lib/simplelambda.js
+++ b/lib/simplelambda.js
@@ -1,170 +1,327 @@
-var vars = "xyzwvutsrabcdefghijklmnopq";
+var freshCounter = 0;
+
+/* Each term has methods toString, toHTML, substitute, hasFree, and getFreeVars.
+* Only Apply has the method 'reduce'.
+* Variables must be lowercase.
+* */
+
 function Variable(name) {
-    if (!isLetter(name))
-        throw "invalid variable name";
-        
-    this.toString = function () {
-        return name;
+  if (!isIdentifier(name))
+    throw "invalid variable name";
+
+  this.toHTML = function(boundVars){
+    if (typeof(boundVars)!=typeof([])) boundVars = [];
+    var isFree = boundVars.indexOf(name) == -1;
+    var htmlName = name;
+    var subscript = '';
+    if (name.match(/^[a-z][0-9]+$/)) {
+      subscript = '<sub>' + name.substr(1) + '</sub>';
+      htmlName = name.substr(0,1);
     }
-    
-    this.substitute = function (varname, newterm) {
-        if (name === varname)
-            return newterm;
-            
-        return this;
-    }        this.hasFree = function (varname) {        return name === varname;    }        this.getFresh = function () {        return freshVariable(name);    }
+    return "<i>" + (isFree ? "<b>" + htmlName + "</b>" : htmlName) + "</i>" + subscript;
+  };
+
+  this.toString = function () {
+    return name;
+  };
+
+  this.substitute = function (varname, newterm) {
+    if (name === varname)
+      return newterm;
+    else
+     return this;
+  };
+
+  this.hasFree = function (varname) {
+    return name === varname;
+  };
+
+  this.getFreeVars = function () {
+    return [name];
+  };
+
+  this.getName = function() {
+    return name;
+  }
+
 }
 
-function isLetter(text) {
-    if (!text)
-        return false;
-        
-    if (text.length != 1)
-        return false;
-        
-    if (text < 'a' || text > 'z')
-        return false;
-        
-    return true;
-}function freshVariable(name) {    var p = vars.indexOf(name);    return vars[p + 1];}function freshVariables(v1, v2) {    var p1 = vars.indexOf(v1);    var p2 = vars.indexOf(v2);        if (p1 > p2)        return v1;        return v2;}
+function isIdentifier(text) {
+  return (text && typeof(text) == typeof("") && text.length > 0 && text.match(/^[a-z][0-9]*$/) );
+}
+
+function makeFreshName(boundVars) {
+  var minIndex = 0;
+  var shortVars = "xyzwvutsrabcdefghijklmnopq";
+
+  if (boundVars) {
+    boundVars.forEach(function(bVar){
+      if (bVar.match(/^[a-z]$/)) {
+        shortVars = shortVars.replace(bVar, '');
+      }
+      else if (bVar.match(/^v[0-9]+$/)) {
+        var n = parseInt(bVar.substr(1));
+        if (n>=minIndex) minIndex = n+1;
+      }
+    });
+    var newName = (shortVars.length > 0) ? shortVars.charAt(0) : "v" + minIndex;
+//    console.log('makeFreshName', boundVars, 'returns', newName);
+    return newName;
+  }
+
+  return shortVars.charAt(0);
+}
 
 function Lambda(name, term) {
-    this.toString = function () {
-        return "\\" + name + "." + term.toString();
-    };
-    
-    this.substitute = function (varname, newterm) {        if (name === varname && !Variable.prototype.isPrototypeOf(newterm))            return this;                    if (name !== varname && newterm.hasFree(name)) {            var newname = freshVariables(term.getFresh(), newterm.getFresh());            var term2 = term.substitute(name, new Variable(newname)).substitute(varname, newterm);            return new Lambda(newname, term2);        }    
-        var body = term.substitute(varname, newterm);
-        
-        if (name !== varname)
-            if (body === term)
-                return this;
-            else
-                return new Lambda(name, body);
-                
-        return new Lambda(newterm.toString(), body);
-    };        this.apply = function (newterm) {        return term.substitute(name, newterm);    };        this.hasFree = function (varname) {        if (name === varname)            return false;                    return term.hasFree(varname);    };        this.getFresh = function () {        return freshVariables(freshVariable(name), term.getFresh());    };}
+
+  var boundVar = new Variable(name);
+
+  this.toString = function () {
+    return "\\" + boundVar.toString() + "." + term.toString();
+  };
+
+  this.toHTML = function(boundVars) {
+    if (typeof(boundVars)!=typeof([])) boundVars = [];
+    return "λ" + boundVar.toHTML([name]) + "→" + term.toHTML([name].concat(boundVars));
+  };
+
+  // note: we have two different substitutions, one for the bound variable - and it can only be substituted by another variable, which is alpha-conversion - and another when we substitute a free variable by a new term, which is beta-conversion
+  this.substitute = function (varname, newterm) {
+    if (name === varname && !Variable.prototype.isPrototypeOf(newterm)) {
+      console.log('invalid usage: cannot substitute x by a non-variable in \\x->...; ignored.');
+      return this;
+    }
+
+    if (name !== varname && newterm.hasFree(name)) { // need alpha-conversion
+      var newname = makeFreshName(term.getFreeVars().concat(newterm.getFreeVars())); // guarantee that newname is not free in our term and in newterm
+      var term2 = term.substitute(name, new Variable(newname)).substitute(varname, newterm);
+      return new Lambda(newname, term2);
+    }
+
+    var body = term.substitute(varname, newterm);
+
+    if (name !== varname)
+      if (body === term)
+        return this;
+      else
+        return new Lambda(name, body);
+
+    else {
+      // if we are here, newterm is a variable, and we are simply alpha-renaming ourselves
+      return new Lambda(newterm.getName(), body);
+    }
+  };
+
+  this.apply = function (newterm) {
+    return term.substitute(name, newterm);
+  };
+
+  this.hasFree = function (varname) {
+    return name !== varname && term.hasFree(varname);
+  };
+
+  this.getFreeVars = function () {
+    var termFreeVars = term.getFreeVars();
+    var index = termFreeVars.indexOf(name); // our variable is not free in the term if it occurs there
+    if (index != -1) termFreeVars.splice(index, 1);
+//    console.log('termFreeVars', termFreeVars, 'index', index, 'splicing', termFreeVars.splice(index, 1));
+    return termFreeVars;
+  };
+}
 
 function Apply(left, right) {
-    this.toString = function () {
-        var leftstr = left.toString();
-        var rightstr = right.toString();
-        
-        if (Apply.prototype.isPrototypeOf(right) || Lambda.prototype.isPrototypeOf(right))
-            rightstr = "(" + rightstr + ")";
-        if (Lambda.prototype.isPrototypeOf(left))            leftstr = "(" + leftstr + ")";            
-        return leftstr + rightstr;
-    }
-    
-    this.substitute = function (varname, newterm) {
-        var newleft = left.substitute(varname, newterm);
-        var newright = right.substitute(varname, newterm);
-        
-        if (newleft === left && newright === right)
-            return this;
-            
-        return new Apply(newleft, newright);
-    }        this.reduce = function () {
-        var lreduce = reduce(left);
-        
-        if (lreduce)
-            return new Apply(lreduce, right);
-            
-        var rreduce = reduce(right);
-        
-        if (rreduce)
-            return new Apply(left, rreduce);
-            
-        if (!Lambda.prototype.isPrototypeOf(left))
-            return null;
-            
-        return left.apply(right);
-    }
-    this.hasFree = function (varname) {        return left.hasFree(varname) || right.hasFree(varname);    }
-        this.getFresh = function () {        return freshVariables(left.getFresh(), right.getFresh());    };}
+  this.toHTML = function (boundVars) {
+    if (typeof(boundVars)!=typeof([])) boundVars = [];
+    var leftstr = left.toHTML(boundVars);
+    var rightstr = right.toHTML(boundVars);
+
+    if (Apply.prototype.isPrototypeOf(right) || Lambda.prototype.isPrototypeOf(right))
+      rightstr = "(" + rightstr + ")";
+
+    if (Lambda.prototype.isPrototypeOf(left))
+      leftstr = "&nbsp;(" + leftstr + ")&nbsp;";
+
+    return leftstr + rightstr;
+  };
+
+  this.toString = function () {
+    var leftstr = left.toString();
+    var rightstr = right.toString();
+
+    if (Apply.prototype.isPrototypeOf(right) || Lambda.prototype.isPrototypeOf(right))
+      rightstr = "(" + rightstr + ")";
+
+    if (Lambda.prototype.isPrototypeOf(left))
+      leftstr = "(" + leftstr + ")";
+
+    return leftstr + rightstr;
+  };
+
+  this.substitute = function (varname, newterm) {
+    var newleft = left.substitute(varname, newterm);
+    var newright = right.substitute(varname, newterm);
+
+    if (newleft === left && newright === right)
+      return this;
+
+    return new Apply(newleft, newright);
+  };
+
+  this.reduce = function () {
+    var lreduce = reduce(left);
+
+    if (lreduce)
+      return new Apply(lreduce, right);
+
+    var rreduce = reduce(right);
+
+    if (rreduce)
+      return new Apply(left, rreduce);
+
+    if (!Lambda.prototype.isPrototypeOf(left))
+      return null;
+
+    return left.apply(right);
+  };
+
+  this.hasFree = function (varname) {
+    return left.hasFree(varname) || right.hasFree(varname);
+  };
+
+  this.getFreeVars = function () {
+    return left.getFreeVars().concat(right.getFreeVars());
+  };
+}
 
 function createApply(left, right) {
-    return new Apply(left, right);
+  return new Apply(left, right);
 }
 
 function createVariable(name) {
-    return new Variable(name);
+  return new Variable(name);
 }
 
 function createLambda(name, term) {
-    return new Lambda(name, term);
+  return new Lambda(name, term);
 }
 
 function reduce(term) {
-    if (term.reduce)
-        return term.reduce();
-        
-    return null;
+  if (term.reduce)
+    return term.reduce();
+
+  return null;
 }
 
 
 function parse(text) {
+  var l = text.length;
+  var p = 0;
+
+  var result = parseTerms();
+  if (p != l) {
+    throw "Unexpected '" + text[p] + "'";
+  } else {
+    return result;
+  }
+
+  function parseTerms() {
     var term = null;
-    var l = text.length;
-    var p = 0;
-    
-    return parseTerms();
-    
-    function parseTerms(closed) {
-        var term = null;
-        
-        for (var newterm = parseTerm(closed); newterm; newterm = parseTerm(closed))
-            if (term)
-                term = new Apply(term, newterm);
-            else
-                term = newterm;
-                
+
+    for (var newterm = parseTerm(); newterm; newterm = parseTerm())
+      if (term)
+        term = new Apply(term, newterm);
+      else
+        term = newterm;
+
+    return term;
+  }
+
+  function parseVarName() { // [a-z][0-9]*
+//    console.log('parseVarName at', p, 'input string:', text);
+
+    var name = text[p];
+    if (name >= 'a' && name <= 'z') {
+      p++;
+      while (p < l && text[p] <= '9' && text[p] >= '0') {
+        name += text[p];
+        p++;
+      }
+//      console.log('returns', name);
+      return name;
+
+    } else {
+      return null;
+    }
+  }
+
+  function skipWhitespaceAndCheckEnd() {
+    while (p < l && text[p] <= ' ')
+      p++;
+    return p>=l;
+  }
+
+  function parseFixedString(str) {
+    if (str && str.length > 0 && p + str.length < l && text.substr(p, str.length) == str) {
+      p += str.length;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  function parseCharRange(range) {
+//    console.log('parseCharRange at', p, 'input string:', text);
+
+    if (p < l && range.indexOf(text[p]) != -1) {
+      p++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  // a term is an identifier or a lambda or ( term )
+  function parseTerm() {
+//    console.log('parseTerm at', p, 'input string:', text);
+    if (skipWhitespaceAndCheckEnd()) return null;
+
+    var varName = parseVarName();
+    if (varName) return new Variable(varName);
+
+    if (parseCharRange("\\λ")) {
+      var name = parseVarName();
+
+      if (!name)
+        throw "Invalid argument name";
+
+      if (!parseCharRange(".→") && !parseFixedString('->'))
+        throw "Expected a lambda separator";
+
+      var body = parseTerms();
+
+      return new Lambda(name, body);
+    }
+
+    if (parseCharRange("(")) {
+      var term = parseTerms(); // true
+//      console.log('parsing', text, 'position', p, 'term', term.toString());
+
+      if (parseCharRange(")")) {
         return term;
+      } else {
+        throw "Unclosed term at position " + p + ", input string: " + text;
+      }
     }
-    
-    function parseTerm(closed) {
-        while (p < l && text[p] <= ' ')
-            p++;
-            
-        if (p >= l)
-            return null;
-            
-        var ch = text[p];
-        if (ch == ')' && closed)            return null;                    p++;        
-        if (isLetter(ch))
-            return new Variable(ch);            
-        if (ch == '\\') {
-            var name = text[p++];
-            
-            if (!isLetter(name))
-                throw "Invalid argument name";
-            
-            if (text[p++] != '.')
-                throw "Expected '.'";
-                
-            var body = parseTerms(closed);
-            
-            return new Lambda(name, body);
-        }
-            
-        if (ch == '(') {
-            var term = parseTerms(true);
-            
-            if (text[p] != ')')
-                throw "Unclosed term";                            p++;
-            
-            return term;
-        }
-        
-        throw "Unexpected '" + ch + "'";
-    }
+
+    return null;
+  }
 }
 
 module.exports = {
-    createVariable: createVariable,
-    createLambda: createLambda,
-    createApply: createApply,
-    reduce: reduce,
-    parse: parse
+  createVariable: createVariable,
+  createLambda: createLambda,
+  createApply: createApply,
+  reduce: reduce,
+  parse: parse
 };
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 { "name": "simplelambda"
 , "description": "Lambda calculus implemented as interpreter in JavaScript"
 , "keywords": [ "lambda", "calculus", "javascript" ]
-, "version": "0.0.2"
-, "author": "Angel 'Java' Lopez <webmaster@ajlopez.com> (http://www.ajlopez.com)"
+, "version": "0.0.3"
+, "author": "Sergei Winitzki (http://www.github.com/winitzki)"
 , "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"
 , "engines": { "node": ">= 0.6.0 && < 0.11.0" }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name": "simplelambda"
 , "description": "Lambda calculus implemented as interpreter in JavaScript"
 , "keywords": [ "lambda", "calculus", "javascript" ]
-, "version": "0.0.3"
+, "version": "0.0.4"
 , "author": "Sergei Winitzki (http://www.github.com/winitzki)"
 , "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 , "keywords": [ "lambda", "calculus", "javascript" ]
 , "version": "0.0.1"
 , "author": "Angel 'Java' Lopez <webmaster@ajlopez.com> (http://www.ajlopez.com)"
-, "repository": { "type": "git", "url": "git://github.com/ajlopez/SimpleLambda.git" }
+, "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"
 , "engines": { "node": ">= 0.6.0 && < 0.11.0" }
 , "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name": "simplelambda"
 , "description": "Lambda calculus implemented as interpreter in JavaScript"
 , "keywords": [ "lambda", "calculus", "javascript" ]
-, "version": "0.0.1"
+, "version": "0.0.2"
 , "author": "Angel 'Java' Lopez <webmaster@ajlopez.com> (http://www.ajlopez.com)"
 , "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name": "simplelambda"
 , "description": "Lambda calculus implemented as interpreter in JavaScript"
 , "keywords": [ "lambda", "calculus", "javascript" ]
-, "version": "0.0.5"
+, "version": "0.0.6"
 , "author": "Sergei Winitzki (http://www.github.com/winitzki)"
 , "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name": "simplelambda"
 , "description": "Lambda calculus implemented as interpreter in JavaScript"
 , "keywords": [ "lambda", "calculus", "javascript" ]
-, "version": "0.0.4"
+, "version": "0.0.5"
 , "author": "Sergei Winitzki (http://www.github.com/winitzki)"
 , "repository": { "type": "git", "url": "git://github.com/winitzki/SimpleLambda.git" }
 , "main": "./lib/simplelambda.js"

--- a/test/alphaconvert.js
+++ b/test/alphaconvert.js
@@ -1,0 +1,47 @@
+var sl = require('..');
+
+//exports['Alpha conversion of a variable'] = function (test) {
+//  var a = sl.createVariable('y');
+//
+//  var b = a.alphaConvert('y', 'z');
+//  test.equal(b.toString(), 'z');
+//};
+//
+//exports['Alpha conversion of a variable that has a different name'] = function (test) {
+//  var a = sl.createVariable('x');
+//
+//  var b = a.alphaConvert('y', 'z');
+//  test.equal(b.toString(), 'x');
+//};
+
+// alpha conversion is only defined for lambda terms
+exports['Alpha conversion of a lambda'] = function (test) {
+  var a = sl.createLambda('x', sl.createVariable('x'));
+
+  var b = a.alphaConvert('x', 'z');
+  test.equal(b.toString(), '\\z.z');
+};
+
+exports['Alpha conversion of a lambda for a variable that is not bound'] = function (test) {
+  var a = sl.createLambda('x', sl.createVariable('y'));
+
+  var b = a.alphaConvert('y', 'z');
+  test.equal(b.toString(), '\\x.y');
+};
+
+exports['Alpha conversion of a lambda with non-variable body'] = function (test) {
+  var c = sl.parse('\\x.yxz').substitute('y', sl.createVariable('q'));
+  test.equal(c.toString(), '\\x.qxz');
+};
+exports['Alpha conversion of a lambda with nested body'] = function (test) {
+  var a = sl.parse('\\x.\\y.xy(\\x.x)z');
+  var b = a.alphaConvert('x', 't');
+  test.equal(b.toString(), '\\t.\\y.ty(\\x.x)z');
+};
+
+//exports['Alpha conversion of an application'] = function (test) {
+//  var a = sl.createApply(sl.createVariable('x'), sl.createVariable('y'));
+//
+//  var b = a.alphaConvert('x', 'z');
+//  test.equal(b.toString(), 'zy');
+//};

--- a/test/apply.js
+++ b/test/apply.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Create apply'] = function (test) {

--- a/test/getfresh.js
+++ b/test/getfresh.js
@@ -12,7 +12,7 @@ exports['Get free variables from apply'] = function (test) {
 
 exports['Get free variables from lambda'] = function (test) {
     test.equal(sl.parse('\\x.x').getFreeVars().toString(), [].toString());
-    test.equal(sl.parse('\\x.zy').getFreeVars().toString(), ['z', 'y'].toString());
+    test.equal(sl.parse('\\x.z(\\z.\\y.zxy)y').getFreeVars().toString(), ['z', 'y'].toString());
     test.equal(sl.parse('\\a.ab').getFreeVars().toString(), ['b']);
 };
 

--- a/test/getfresh.js
+++ b/test/getfresh.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Get free variables from variable'] = function (test) {

--- a/test/getfresh.js
+++ b/test/getfresh.js
@@ -1,27 +1,18 @@
 
 var sl = require('..');
 
-exports['Get fresh variable from variable'] = function (test) {
-    test.equal(sl.parse('x').getFresh(), 'y');
-    test.equal(sl.parse('y').getFresh(), 'z');
-    test.equal(sl.parse('z').getFresh(), 'w');
-    test.equal(sl.parse('w').getFresh(), 'v');
-    test.equal(sl.parse('v').getFresh(), 'u');
-    test.equal(sl.parse('u').getFresh(), 't');
-    test.equal(sl.parse('t').getFresh(), 's');
-    test.equal(sl.parse('a').getFresh(), 'b');
+exports['Get free variables from variable'] = function (test) {
+    test.equal(sl.parse('x').getFreeVars().toString(), ['x'].toString());
 };
 
-exports['Get fresh variable from apply'] = function (test) {
-    test.equal(sl.parse('ab').getFresh(), 'c');
-    test.equal(sl.parse('yx').getFresh(), 'z');
-    test.equal(sl.parse('xy').getFresh(), 'z');
-    test.equal(sl.parse('cba').getFresh(), 'd');
+exports['Get free variables from apply'] = function (test) {
+    test.equal(sl.parse('ab').getFreeVars().toString(), ['a','b'].toString());
+    test.equal(sl.parse('cba').getFreeVars().toString(), ['c', 'b', 'a'].toString());
 };
 
-exports['Get fresh variable from lambda'] = function (test) {
-    test.equal(sl.parse('\\x.x').getFresh(), 'y');
-    test.equal(sl.parse('\\x.zy').getFresh(), 'w');
-    test.equal(sl.parse('\\a.bcd').getFresh(), 'e');
+exports['Get free variables from lambda'] = function (test) {
+    test.equal(sl.parse('\\x.x').getFreeVars().toString(), [].toString());
+    test.equal(sl.parse('\\x.zy').getFreeVars().toString(), ['z', 'y'].toString());
+    test.equal(sl.parse('\\a.ab').getFreeVars().toString(), ['b']);
 };
 

--- a/test/hasfree.js
+++ b/test/hasfree.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Variable has itself as free'] = function (test) {

--- a/test/isequal.js
+++ b/test/isequal.js
@@ -45,6 +45,16 @@ exports['Two lambdas are equal when they are equivalent by alpha-conversion invo
   test.equal(sl.isEqual(l1, l2), true);
 };
 
+exports['Two lambdas are equal when they are equivalent by alpha-conversion involving deeper nesting'] = function (test) {
+  var l1 = sl.parse('\\x.\\y.x(\\z.\\t.txyz)');
+  var l2 = sl.parse('\\a.\\b.a(\\c.\\d.dabc)');
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+
 exports['Two lambdas are not equal when they are not equivalent'] = function (test) {
   var l1 = sl.createLambda('x', sl.createVariable('y'));
   var l2 = sl.createLambda('y', sl.createVariable('y'));

--- a/test/isequal.js
+++ b/test/isequal.js
@@ -45,16 +45,6 @@ exports['Two lambdas are equal when they are equivalent by alpha-conversion invo
   test.equal(sl.isEqual(l1, l2), true);
 };
 
-exports['Two lambdas are equal when they are equivalent by alpha-conversion involving deeper nesting'] = function (test) {
-  var l1 = sl.parse('\\x.\\y.x(\\z.\\t.txyz)');
-  var l2 = sl.parse('\\a.\\b.a(\\c.\\d.dabc)');
-
-  test.ok(l1);
-  test.ok(l2);
-  test.equal(sl.isEqual(l1, l2), true);
-};
-
-
 exports['Two lambdas are not equal when they are not equivalent'] = function (test) {
   var l1 = sl.createLambda('x', sl.createVariable('y'));
   var l2 = sl.createLambda('y', sl.createVariable('y'));
@@ -73,4 +63,11 @@ exports['Two applications are equal when they are identical'] = function (test) 
   test.equal(sl.isEqual(l1, l2), true);
 };
 
+exports['Two lambdas are equal when they are equivalent by alpha-conversion involving deep nesting'] = function (test) {
+  var l1 = sl.parse('\\x.\\y.x(\\z.\\t.txyz)(\\y.xy)');
+  var l2 = sl.parse('\\a.\\b.a(\\c.\\d.dabc)(\\q.aq)');
 
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};

--- a/test/isequal.js
+++ b/test/isequal.js
@@ -1,0 +1,66 @@
+var sl = require('..');
+
+exports['Two vars are equal when they are identical'] = function (test) {
+  var l1 = sl.createVariable('y');
+  var l2 = sl.createVariable('y');
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+exports['Two vars are not equal when they are not identical'] = function (test) {
+  var l1 = sl.createVariable('x');
+  var l2 = sl.createVariable('y');
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), false);
+};
+
+exports['Two lambdas are equal when they are identical'] = function (test) {
+  var l1 = sl.createLambda('x', sl.createVariable('y'));
+  var l2 = sl.createLambda('x', sl.createVariable('y'));
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+exports['Two lambdas are equal when they are equivalent by alpha-conversion not involving bound variable'] = function (test) {
+  var l1 = sl.createLambda('x', sl.createVariable('y'));
+  var l2 = sl.createLambda('z', sl.createVariable('y'));
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+exports['Two lambdas are equal when they are equivalent by alpha-conversion involving bound variable'] = function (test) {
+  var l1 = sl.createLambda('x', sl.createVariable('x'));
+  var l2 = sl.createLambda('z', sl.createVariable('z'));
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+exports['Two lambdas are not equal when they are not equivalent'] = function (test) {
+  var l1 = sl.createLambda('x', sl.createVariable('y'));
+  var l2 = sl.createLambda('y', sl.createVariable('y'));
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), false);
+};
+
+exports['Two applications are equal when they are identical'] = function (test) {
+  var l1 = sl.createApply(sl.createVariable('x'), sl.createVariable('y'));
+  var l2 = sl.createApply(sl.createVariable('x'), sl.createVariable('y'));
+
+  test.ok(l1);
+  test.ok(l2);
+  test.equal(sl.isEqual(l1, l2), true);
+};
+
+

--- a/test/lambda.js
+++ b/test/lambda.js
@@ -24,12 +24,20 @@ exports['Substitute not bound variable'] = function (test) {
     test.equal(result.toString(), "\\x.z");
 };
 
-exports['Substitute not bound variable and replace bound variable that is free in new term'] = function (test) {
+exports['Substitute non-bound variable and replace bound variable that is free in new term'] = function (test) {
     var l = sl.createLambda('x', sl.createVariable('y'));
     
     var result = l.substitute('y', sl.createVariable('x'));
     test.ok(result);
     test.equal(result.toString(), "\\z.x");
+};
+
+exports['Alpha-conversion does not confusingly use the names of free variables'] = function (test) {
+  var l = sl.parse('(\\x.\\x.x)p');
+
+  var result = l.reduce();
+  test.ok(result);
+  test.equal(result.toString(), "\\x.x");
 };
 
 exports['Alpha-conversion works also for the variable q'] = function (test) {
@@ -41,7 +49,7 @@ exports['Alpha-conversion works also for the variable q'] = function (test) {
 };
 
 exports['Substitute and change argument by fresh variable'] = function (test) {
-    var l = sl.createLambda('x', sl.createVariable('y'));
+    var l = sl.parse('\\x.y');
     
     var result = l.substitute('y', sl.parse('abcx'));
     test.ok(result);
@@ -56,7 +64,7 @@ exports["Don't substitute not found variable"] = function (test) {
     test.equal(result.toString(), "\\x.y");
 };
 
-exports["Don't substitute bound variable by a not variable term"] = function (test) {
+exports["Don't substitute bound variable by a non-variable term"] = function (test) {
     var l = sl.createLambda('x', sl.createVariable('y'));
     
     var result = l.substitute('x', sl.createLambda('y', sl.createVariable('z')));

--- a/test/lambda.js
+++ b/test/lambda.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Create lambda'] = function (test) {
@@ -8,15 +7,15 @@ exports['Create lambda'] = function (test) {
     test.equal(l.toString(), "\\x.y");
 };
 
-exports['Substitute bound variable'] = function (test) {
-    var l = sl.createLambda('x', sl.createVariable('x'));
+exports['Substitute bound variable does nothing'] = function (test) {
+    var l = sl.createLambda('x', sl.createVariable('x')); //   \x.x
     
     var result = l.substitute('x', sl.createVariable('y'));
     test.ok(result);
-    test.equal(result.toString(), "\\y.y");
+    test.equal(result.toString(), "\\x.x");
 };
 
-exports['Substitute not bound variable'] = function (test) {
+exports['Substitute non-bound variable'] = function (test) {
     var l = sl.createLambda('x', sl.createVariable('z'));
     
     var result = l.substitute('y', sl.createVariable('z'));

--- a/test/lambda.js
+++ b/test/lambda.js
@@ -32,12 +32,20 @@ exports['Substitute not bound variable and replace bound variable that is free i
     test.equal(result.toString(), "\\z.x");
 };
 
+exports['Alpha-conversion works also for the variable q'] = function (test) {
+  var l = sl.createLambda('x', sl.createVariable('q'));
+
+  var result = l.substitute('q', sl.createVariable('x'));
+  test.ok(result);
+  test.equal(result.toString(), "\\y.x");
+};
+
 exports['Substitute and change argument by fresh variable'] = function (test) {
     var l = sl.createLambda('x', sl.createVariable('y'));
     
     var result = l.substitute('y', sl.parse('abcx'));
     test.ok(result);
-    test.equal(result.toString(), "\\d.abcx");
+    test.equal(result.toString(), "\\z.abcx");
 };
 
 exports["Don't substitute not found variable"] = function (test) {
@@ -54,6 +62,15 @@ exports["Don't substitute bound variable by a not variable term"] = function (te
     var result = l.substitute('x', sl.createLambda('y', sl.createVariable('z')));
     test.ok(result);
     test.equal(result.toString(), "\\x.y");
+};
+
+exports['Alpha-conversion generates longer names when all short names are exhausted'] = function (test) {
+  var l = sl.createLambda('x', sl.parse('xyzwvutsrabcdefghijklmnopq'));
+  var m = l.substitute('q',sl.createVariable('x'));
+  test.equal(m.toString(), "\\v0.v0yzwvutsrabcdefghijklmnopx");
+  var result = m.substitute('p', sl.createApply(sl.parse('xq'),sl.createVariable('v0')));
+  test.ok(result);
+  test.equal(result.toString(), "\\v1.v1yzwvutsrabcdefghijklmno(xqv0)x");
 };
 
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -48,6 +48,14 @@ exports['Parse three variables, two capitalized, ignoring spaces'] = function (t
     test.equal(v.toString(), 'xYgrecZed');
 };
 
+exports['Parse a lambda with capitalized variables'] = function (test) {
+    var v = sl.parse('\\x.\\Ygrec.Zed');
+
+    test.ok(v);
+    test.equal(typeof v, 'object');
+    test.equal(v.toString(), '\\x.\\Ygrec.Zed');
+};
+
 
 exports['Parse three variables'] = function (test) {
     var v = sl.parse('xyz');
@@ -134,12 +142,12 @@ exports['Throw exception when invalid argument'] = function (test) {
     );
 };
 
-exports['Throw exception when missing point in lambda'] = function (test) {
-    test.throws(
-        function() { sl.parse("\\xy"); },
-        "Expected"
-    );
-};
+//exports['Throw exception when missing point in lambda'] = function (test) {
+//    test.throws(
+//        function() { sl.parse("\\xy"); },
+//        "Expected"
+//    );
+//};
 
 exports['Parse a term, print it, parse again, print results in the same expression'] = function (test) {
   var v = sl.parse('((\\x.x)y(\\x.\\y.(\\z.zxy)))');
@@ -152,5 +160,20 @@ exports['Parse a term, print it, parse again, print results in the same expressi
   test.equal(v.toString(), newV.toString());
 };
 
+exports['Parse lambdas without separator'] = function (test) {
+  var v = sl.parse('\\y\\xxy');
 
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toString(), '\\y.\\x.xy');
+};
+
+
+exports['Parse nested lambda without separator'] = function (test) {
+  var v = sl.parse('\\y(\\xx)y');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toString(), '\\y.(\\x.x)y');
+};
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -79,6 +79,14 @@ exports['Parse simple lambda'] = function (test) {
     test.equal(v.toString(), '\\x.x');
 };
 
+exports['Parse simple lambda with ->'] = function (test) {
+  var v = sl.parse('\\x->x');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toString(), '\\x.x');
+};
+
 exports['Parse lambda enclosed in parenthesis'] = function (test) {
     var v = sl.parse('(\\x.x)');
     
@@ -105,10 +113,20 @@ exports['Throw exception when invalid argument'] = function (test) {
 exports['Throw exception when missing point in lambda'] = function (test) {
     test.throws(
         function() { sl.parse("\\xy"); },
-        "Expected '.'"
+        "Expected"
     );
 };
 
+exports['Parse a term, print it, parse again, print results in the same expression'] = function (test) {
+  var v = sl.parse('((\\x.x)y(\\x.\\y.(\\z.zxy)))');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+
+  var newV = sl.parse(v.toString());
+
+  test.equal(v.toString(), newV.toString());
+};
 
 
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Parse variable'] = function (test) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -24,6 +24,31 @@ exports['Parse two variables'] = function (test) {
     test.equal(v.toString(), 'xy');
 };
 
+exports['Parse capitalized variable skipping spaces'] = function (test) {
+    var v = sl.parse(' Capitalized');
+
+    test.ok(v);
+    test.equal(typeof v, 'object');
+    test.equal(v.toString(), 'Capitalized');
+};
+
+exports['Parse three variables, two capitalized'] = function (test) {
+    var v = sl.parse('xYgrecZed');
+
+    test.ok(v);
+    test.equal(typeof v, 'object');
+    test.equal(v.toString(), 'xYgrecZed');
+};
+
+exports['Parse three variables, two capitalized, ignoring spaces'] = function (test) {
+    var v = sl.parse('xYgrec Zed ');
+
+    test.ok(v);
+    test.equal(typeof v, 'object');
+    test.equal(v.toString(), 'xYgrecZed');
+};
+
+
 exports['Parse three variables'] = function (test) {
     var v = sl.parse('xyz');
     

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Reduce variable'] = function (test) {
@@ -32,6 +31,30 @@ exports['Reduce complex term'] = function (test) {
     term = sl.reduce(term);
     test.ok(term);
     test.equal(term.toString(), 'y');
+};
+
+exports['Reduce more terms 1'] = function (test) {
+    var term = sl.parse('\\x.(\\y.x)x');
+    test.ok(term);
+    term = sl.reduce(term);
+    test.ok(term);
+    test.equal(term.toString(), '\\x.x');
+};
+
+exports['Reduce more terms 2'] = function (test) {
+    var term = sl.parse('\\y.(\\x.x)x');
+    test.ok(term);
+    term = sl.reduce(term);
+    test.ok(term);
+    test.equal(term.toString(), '\\y.x');
+};
+
+exports['Reduce more terms 3'] = function (test) {
+    var term = sl.parse('(\\x.\\y.x)(xy)');
+    test.ok(term);
+    term = sl.reduce(term);
+    test.ok(term);
+    test.equal(term.toString(), '\\z.xy');
 };
 
 exports['Reduce the body of lambda'] = function (test) {

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -4,23 +4,23 @@ var sl = require('..');
 exports['Reduce variable'] = function (test) {
     var term = sl.parse('x');    
     test.equal(sl.reduce(term), null);
-}
+};
 
 exports['Reduce lambda'] = function (test) {
     var term = sl.parse('\\x.x');
     test.equal(sl.reduce(term), null);
-}
+};
 
 exports['Reduce simple apply'] = function (test) {
     var term = sl.parse('xy');
     test.equal(sl.reduce(term), null);
-}
+};
 
 exports['Reduce apply with left lambda'] = function (test) {
     var term = sl.reduce(sl.parse('(\\x.x)y'));
     test.ok(term);
     test.equal(term.toString(), 'y');
-}
+};
 
 exports['Reduce complex term'] = function (test) {
     var term = sl.reduce(sl.parse('(\\x.y)((\\z.zz)(\\w.w))'));
@@ -32,5 +32,14 @@ exports['Reduce complex term'] = function (test) {
     term = sl.reduce(term);
     test.ok(term);
     test.equal(term.toString(), 'y');
-}
+};
 
+exports['Reduce the body of lambda'] = function (test) {
+    var term = sl.reduce(sl.parse('\\x.(\\z.z)y'));
+    test.ok(term);
+    test.equal(term.toString(), '\\x.y');
+};
+exports['Do not reduce the body of lambda if given keepLambdaBody=true'] = function (test) {
+    var term = sl.reduce(sl.parse('\\x.(\\z.z)y'), { keepLambdaBody: true });
+    test.equal(term, null);
+};

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -66,3 +66,8 @@ exports['Do not reduce the body of lambda if given keepLambdaBody=true'] = funct
     var term = sl.reduce(sl.parse('\\x.(\\z.z)y'), { keepLambdaBody: true });
     test.equal(term, null);
 };
+exports['Reduce lazily if the option is given'] = function (test) {
+    var term = sl.reduce(sl.parse('(\\x.y)((\\z.zzzzz)t)'), { lazyEvaluation: true });
+    test.ok(term);
+    test.equal(term.toString(), 'y');
+};

--- a/test/tohtml.js
+++ b/test/tohtml.js
@@ -13,7 +13,7 @@ exports['Print lambda with two free variables'] = function (test) {
 
   test.ok(v);
   test.equal(typeof v, 'object');
-  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i><i><b>y</b></i><i><b>z</b></i>');
+  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i>&nbsp;<i><b>y</b></i>&nbsp;<i><b>z</b></i>');
 };
 
 exports['Print variables with subscripts'] = function (test) {
@@ -21,5 +21,5 @@ exports['Print variables with subscripts'] = function (test) {
 
   test.ok(v);
   test.equal(typeof v, 'object');
-  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i><i><b>y</b></i><sub>23</sub><i><b>z</b></i><sub>3</sub>');
+  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i>&nbsp;<i><b>y</b></i><sub>23</sub>&nbsp;<i><b>z</b></i><sub>3</sub>');
 };

--- a/test/tohtml.js
+++ b/test/tohtml.js
@@ -13,6 +13,7 @@ exports['Print lambda with two free variables'] = function (test) {
 
   test.ok(v);
   test.equal(typeof v, 'object');
+  sl.setLambdaSeparator('→');
   test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i>&nbsp;<i><b>y</b></i>&nbsp;<i><b>z</b></i>');
 };
 
@@ -21,5 +22,6 @@ exports['Print variables with subscripts'] = function (test) {
 
   test.ok(v);
   test.equal(typeof v, 'object');
-  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i>&nbsp;<i><b>y</b></i><sub>23</sub>&nbsp;<i><b>z</b></i><sub>3</sub>');
+  sl.setLambdaSeparator('.');
+  test.equal(v.toHTML(), 'λ<i>x</i>.<i>x</i>&nbsp;<i><b>y</b></i><sub>23</sub>&nbsp;<i><b>z</b></i><sub>3</sub>');
 };

--- a/test/tohtml.js
+++ b/test/tohtml.js
@@ -1,0 +1,25 @@
+var sl = require('..');
+
+exports['Print free variable'] = function (test) {
+  var v = sl.parse('x');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toHTML(), '<i><b>x</b></i>');
+};
+
+exports['Print lambda with two free variables'] = function (test) {
+  var v = sl.parse('\\x.xyz');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i><i><b>y</b></i><i><b>z</b></i>');
+};
+
+exports['Print variables with subscripts'] = function (test) {
+  var v = sl.parse('\\x.xy23z3');
+
+  test.ok(v);
+  test.equal(typeof v, 'object');
+  test.equal(v.toHTML(), 'λ<i>x</i>→<i>x</i><i><b>y</b></i><sub>23</sub><i><b>z</b></i><sub>3</sub>');
+};

--- a/test/variable.js
+++ b/test/variable.js
@@ -41,7 +41,7 @@ exports['Create a variable with one letter and digits'] = function (test) {
   test.equal(v.toString(), 'x23');
 }
 
-exports['Fail to create a variable with not letter character'] = function (test) {
+exports['Fail to create a variable with non-letter character'] = function (test) {
     test.throws(
         function () { sl.createVariable('(') },
         "Invalid variable name"

--- a/test/variable.js
+++ b/test/variable.js
@@ -1,4 +1,3 @@
-
 var sl = require('..');
 
 exports['Create variable'] = function (test) {

--- a/test/variable.js
+++ b/test/variable.js
@@ -35,6 +35,13 @@ exports['Fail to create a variable with two letters'] = function (test) {
     );
 }
 
+exports['Create a variable with one letter and digits'] = function (test) {
+  var v = sl.createVariable('x23');
+
+  test.ok(v);
+  test.equal(v.toString(), 'x23');
+}
+
 exports['Fail to create a variable with not letter character'] = function (test) {
     test.throws(
         function () { sl.createVariable('(') },


### PR DESCRIPTION
Various enhancements to SimpleLambda 0.0.1
- variables can have numeric suffixes now, e.g. `\x1.\y23.x1y23`
- variables with numeric suffixes will be automatically generated as needed
- alpha-conversion now works correctly in all cases, and more conservatively than before, e.g. `\x.(\x.x)p` will be reduced to `\x.x` rather than to `\p.p` as before
- parsing is cleaner and now accepts a wider variety of input syntax, such as `\x->y` or `λx→y`
- a new function `toHTML()` will create nice-looking and somewhat configurable HTML representations for lambda terms
- reduction now also works inside the body of a lambda (this can be switched off by an option), so `\x.(\y.y)z` is now reduced to `\x.z`
- a new function `isEqual()` will compare lambda terms up to alpha-conversions
